### PR TITLE
Random forests

### DIFF
--- a/code/analysis/grf_examples.R
+++ b/code/analysis/grf_examples.R
@@ -43,7 +43,7 @@ func <-
   as.formula()
 
 rf <-
-  function %>%
+  func %>%
   regression_forest2(df)
 
 sample_fig <-

--- a/code/analysis/grf_examples.R
+++ b/code/analysis/grf_examples.R
@@ -20,28 +20,48 @@ library(tidyverse)
 library(grf)
 
 #===========
-# Michael Cahana's canned and pre-labeled pairs
+# data read-in
 #===========
+
+# pre-labeled pairs for training
 df <- 
-  read_csv(file.path(dropbox, 'archive', 'lease_match_sample.csv')) %>%
-  filter(!is.na(keep))
+  c(paste(file.path(dropbox, 'archive'), 
+    c('lease_match_sample.csv', 'new_lease_sample.csv'), sep='/')) %>% 
+  map_df(read_csv) %>% 
+  filter(!is.na(keep)) %>% 
+  distinct(name, match, .keep_all = T) 
+
+# all name matches
+name_matches <- read_csv(file.path(vdir, 'leases_matches.csv'))
 
 #===========
 # example grf use
 #===========
-rf <-
-  paste("shared_words", "cosine_similarity", "dist_score", sep = "+") %>%
+func <-  
+  paste("shared_words", "cosine_similarity", "jw_distance", sep = "+") %>%
   paste("keep", ., sep = "~") %>%
-  as.formula %>%
+  as.formula()
+
+rf <-
+  function %>%
   regression_forest2(df)
 
-fig <-
+sample_fig <-
   rf %>%
   predict %>%
   as_tibble %>%
   bind_cols(df) %>% 
   ggplot(aes(x = predictions, fill = as.factor(keep))) + 
   geom_histogram(position = 'dodge') + 
-  scale_x_continuous(breaks = seq(.0,.8,.1)) + 
+  scale_x_continuous(breaks = seq(.0,1,.1)) + 
   scale_fill_discrete(name = "keep")
 
+name_matches_fig <-
+  rf %>%
+  predict2(func, name_matches) %>%
+  as_tibble() %>%
+  bind_cols(name_matches) %>% 
+  ggplot(aes(x = predictions, fill = as.factor(keep))) + 
+  geom_histogram(position = 'dodge') + 
+  scale_x_continuous(breaks = seq(.0,1,.1)) + 
+  scale_fill_discrete(name = "keep")

--- a/code/functions/match_names.R
+++ b/code/functions/match_names.R
@@ -176,10 +176,26 @@ get_matches <- function(words, bag, row_comparison = FALSE) {
     return (list(indices, strings))
 }
 
+# determine number of shared non-common words between name and match
+shared_words <- function(name, match) {
+    words1 <- get_words(name, drop_common_words = F)
+    words2 <- get_words(match, drop_common_words = F)
+    matches <- get_matches(words1, words2, row_comparison = T)[[2]]
+    if (!is.null(matches)) {
+        return_val <- str_count(matches, '\\|') + 1 
+        if (identical(return_val, numeric(0))) {
+            return_val <- 0
+        }
+    } else {
+        return_val <- 0
+    }
+    return(return_val)
+}
+
 # match names using stringdist methods (default Jaro-Winkler)
 # matches are only those with scores that are at or below the threshold
 match_names_stringdist <- function(names, clean_names, 
-    method='jw', threshold=0.25) {
+    method='jw', threshold) {
 
     count <- 0
     while (length(clean_names)>0) {
@@ -263,7 +279,7 @@ match_names_shared_word <- function(names, ...) {
 
 # match names using cosine similarity scores, matches only being those that
 # are at or exceed the given threshold
-match_names_cosine <- function(names, similarity_matrix, threshold=0.4) {
+match_names_cosine <- function(names, similarity_matrix, threshold) {
     count <- 0
     for (i in 1:dim(names)[1]) {
         name <- names %>% 
@@ -334,7 +350,7 @@ extract_idf <- function(word, idfs) {
     return (idf)
 }
 
-match_names <- function(df, output_file, cosine_threshold =  0.4, 
+match_names <- function(df, output_file, cosine_threshold = 0.4, 
     jaro_threshold = 0.15, write_csv = TRUE) {
 
     #=================================

--- a/code/functions/pre_screen_names.R
+++ b/code/functions/pre_screen_names.R
@@ -151,7 +151,7 @@ pre_screen_names <- function(name_matches, address_matches, lease_count,
 			name_matches %>% 
 			inner_join(filter(reviewed_pairs, keep == 0), 
 				by = c('name', 'match')) %>% 
-			select(-c('keep.x', 'keep.y', 'n.x', 'n.y', 'n', 'pct_coverage'))
+			select(-c('keep.x', 'keep.y', 'n.x', 'n.y'))
 	}
 
 	# if we already did some human review on these matches, incorporate it, 
@@ -162,10 +162,7 @@ pre_screen_names <- function(name_matches, address_matches, lease_count,
 			pre_existing_name_matches %>% 
 			bind_rows(name_matches) %>% 
 			distinct(name, match, .keep_all = T) %>% 
-			select(-n) %>% 
-			mutate(n = n.x + n.y) %>% 
-		    arrange(desc(n)) %>% 
-		    mutate(pct_coverage = cumsum(n)/sum(n)) 
+			arrange(importance_dist)
 	}
 
 	# if we already have some group matches (that is, verified matches from 
@@ -237,7 +234,7 @@ pre_screen_names <- function(name_matches, address_matches, lease_count,
 			name_matches %>% 
 			rf_predict(file.path(ddir, 'training', 
 				'lease_match_sample.csv')) %>% 
-			mutate(keep = ifelse(rf_prob<=0.3, 0, keep))
+			mutate(keep = ifelse((rf_prob<=0.2 & is.na(keep)), 0, keep))
 	}	
 
 	# write out notification files for pairs previously marked as incorrect

--- a/code/functions/pre_screen_names.R
+++ b/code/functions/pre_screen_names.R
@@ -75,7 +75,7 @@ rf_predict <- function(df, train_file_path) {
   		rf %>%
   		predict2(func, df) %>%
   		as_tibble() %>%
-  		bind_cols(name_matches, .) %>% 
+  		bind_cols(df, .) %>% 
   		rename(rf_prob = predictions)
 
   	return(df)

--- a/code/functions/pre_screen_names.R
+++ b/code/functions/pre_screen_names.R
@@ -81,12 +81,30 @@ rf_predict <- function(df, train_file_path) {
   	return(df)
 }
 
+calculate_distance <- function(df, max_threshold, min_threshold) {
+	df <-
+		df %>% 
+		rowwise() %>% 
+		mutate(importance_dist = case_when(
+			max_n >= max_threshold & min_n < min_threshold ~ 
+				min_threshold - min_n, 
+			max_n < max_threshold & min_n >= min_threshold ~ 
+				max_threshold - max_n, 
+			max_n < max_threshold & min_n < min_threshold ~ 
+				raster::pointDistance(c(max_n, min_n), 
+					c(max_threshold, min_threshold), lonlat = F), 
+			max_n >= max_threshold & min_n >= min_threshold ~ 
+				0
+			))
+	return (df)
+}
+
 pre_screen_names <- function(name_matches, address_matches, lease_count, 
 	output_file) {
 
 	# verify name matches that have an address match, add in lease counts, 
 	# calculate closeness scores and minimum n's for each pair, adjust n's to 
-	# avoid double counting, and create cumulative percentage coverage
+	# avoid double counting 
 	name_matches <- 
 		name_matches %>% 
 		left_join(address_matches, by = c('name','match')) %>% 
@@ -103,10 +121,20 @@ pre_screen_names <- function(name_matches, address_matches, lease_count,
 	    mutate(n.x = ifelse(duplicated(name), 0, n.x)) %>% 
 	    mutate(n.y = ifelse(duplicated(match), 0, n.y)) %>% 
 	    mutate(n.y = ifelse(match %in% .$name, 0, n.y)) %>% 
-	    replace_na(list(n.x = 0, n.y = 0)) %>% 
-	    mutate(n = n.x + n.y) %>% 
-	    arrange(desc(n)) %>% 
-	    mutate(pct_coverage = cumsum(n)/sum(n)) 
+	    replace_na(list(n.x = 0, n.y = 0))
+
+	# mark match pairs we deem "important" based on their count coverage
+	# note that the importance_dist variable will represent the distance 
+	# an (x,y) pair is from being within both min and max thresholds 
+	# (x here is max_n, and y min_n)
+	count_deciles <- lease_count %>% pull %>% quantile(probs = seq(.1,1,.1))
+	seventieth_percentile <- count_deciles[7]
+	ninetieth_percentile <- count_deciles[9]
+
+	name_matches <- 
+		name_matches %>% 
+		calculate_distance(ninetieth_percentile, seventieth_percentile) %>% 
+		arrange(importance_dist)
 
 	# determine pairs that are now verified as correct but previously were not, 
 	# if relevant 

--- a/code/functions/random_forest_utils.R
+++ b/code/functions/random_forest_utils.R
@@ -257,3 +257,18 @@ rf_logcausal2 <- function(f, d, ...) {
   return(rf_logcausal(X, Y, W, ...))
 }
 
+# apply a regression forest with a formula onto a new dataframe to generate 
+# predictions. the formula y ~ w | x1 + x2 + x3 means estimate a 
+# regression forest for the outcome y, where the splitting variables are x1, 
+# x2, and x3
+predict2 <- function(rf, f, d, ...) {
+  f <- Formula(f)
+
+  X <-
+    formula(f, rhs = 1, lhs = 0) %>%
+    update(~ 0 + .) %>%
+    model.matrix(d)
+
+  return(predict(rf, X))
+}
+


### PR DESCRIPTION
- Use random forest predicted "probabilities" (keep scores ranging from 0 to 1, not actual probabilities) to screen our match pairs that are highly likely to be false positives
- Determine which pairs humans should review as those whose minimum n is >= the 70th percentile of the n distribution, and whose maximum n is >= the 90th percentile of the n distribution
- Order match pairs in "reviewed_data" according to their distance from this two-dimensional cutoff. The variable representing this distance is labeled `importance_dist`, and represents the Euclidean distance from a (max_n, min_n) point to the graph quadrant (the 1st quadrant of the 1st quadrant, which is to the say the a square in the top right corner of the first quadrant) satisfying both maximum and minimum inequalities. If a (max_n, min_n) point is already within that quadrant, its `importance_dist` is set to 0. Humans should only review the first N rows where `importance_dist==0` 